### PR TITLE
agent any

### DIFF
--- a/_pro/jenkins-support/quickstart.md
+++ b/_pro/jenkins-support/quickstart.md
@@ -83,7 +83,7 @@ jenkinsfileRunner:
 
 ```groovy
 pipeline {
-    agent none
+    agent any
     stages {
         stage('Print message') {
           steps {


### PR DESCRIPTION
Is it better to say "any" to make it clearer? I have used that in the past - is there a reason not to?